### PR TITLE
#3 Enable Open Policy Agent(OPA) GatekeeperV2 using Azure Policy

### DIFF
--- a/aks/aks.tf
+++ b/aks/aks.tf
@@ -97,6 +97,10 @@ resource "azurerm_kubernetes_cluster" "k8s" {
         enabled                    = true
         log_analytics_workspace_id = azurerm_log_analytics_workspace.k8s.id
         }
+
+        azure_policy {
+            enabled = true
+        }
     }
 
     role_based_access_control {
@@ -115,4 +119,8 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     kubernetes_version = "1.17.0"
 
     node_resource_group = "${var.resource_group_name}-node-rg"
+
+    provisioner "local-exec" {
+        command = "${path.cwd}/aks/azurepolicy.sh ${self.name} ${self.resource_group_name}"
+  }
 }

--- a/aks/azurepolicy.sh
+++ b/aks/azurepolicy.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+cluster_name=$1
+rg_name=$2
+
+# Provider register: Register the Azure Kubernetes Services provider
+cs_registered=`az provider show -n Microsoft.ContainerService -o json | jq .registrationState`
+if test $cs_registered != \"Registered\"
+then 
+    az provider register --namespace Microsoft.ContainerService
+else 
+    echo "provider Microsoft.ContainerService already registered"
+fi
+
+# Provider register: Register the Azure Policy provider
+ap_registered=`az provider show -n Microsoft.PolicyInsights -o json | jq .registrationState`
+if test $ap_registered != \"Registered\"
+then 
+    az provider register --namespace Microsoft.PolicyInsights
+else 
+    echo "provider Microsoft.PolicyInsights already registered"
+fi
+
+# Feature register: enables installing the add-on
+feature_registerd=`az feature show --namespace Microsoft.ContainerService --name AKS-AzurePolicyAutoApprove | jq .properties.state`
+if test $feature_registerd != \"Registered\"
+then 
+    az feature register --namespace Microsoft.ContainerService --name AKS-AzurePolicyAutoApprove
+else
+    echo "Microsoft.ContainerService AKS-AzurePolicyAutoApprove already registered"
+fi
+
+while test $feature_registerd != \"Registered\"
+do 
+    sleep 10; 
+    feature_registerd=`az feature show --namespace Microsoft.ContainerService --name AKS-AzurePolicyAutoApprove | jq .properties.state`
+done
+
+# Once the above shows 'Registered' run the following to propagate the update
+az provider register -n Microsoft.ContainerService
+
+feature_registerd=`az feature show --namespace Microsoft.PolicyInsights --name AKS-DataplaneAutoApprove | jq .properties.state`
+if test $feature_registerd != \"Registered\"
+then 
+    az feature register --namespace Microsoft.PolicyInsights --name AKS-DataplaneAutoApprove
+else
+    echo "Microsoft.PolicyInsights AKS-DataplaneAutoApprove already registered"
+fi
+
+while test $feature_registerd != \"Registered\"
+do 
+    sleep 10; 
+    feature_registerd=`az feature show --namespace Microsoft.PolicyInsights --name AKS-DataplaneAutoApprove | jq .properties.state`
+done
+
+# Once the above shows 'Registered' run the following to propagate the update
+az provider register -n Microsoft.PolicyInsights
+
+az extension add --name aks-preview
+az aks enable-addons --addons azure-policy --name $cluster_name --resource-group $rg_name


### PR DESCRIPTION
Azure policy is enabled now on the cluster. No policy assignments are done though and they will be done in subsequent issues.